### PR TITLE
chore: set Vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/web-moi/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- configure Vite to serve project from `/web-moi/`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75e2e50f0832497ac1ddec7186708