### PR TITLE
Remove complementary services section

### DIFF
--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -66,15 +66,6 @@ const ServicesPage: React.FC = () => {
     }
   ];
 
-  const addons = [
-    { name: "Logo personnalisé", price: "250€" },
-    { name: "Rédaction de contenu (par page)", price: "80€" },
-    { name: "Séance photo produits", price: "300€" },
-    { name: "Formation approfondie (2h)", price: "150€" },
-    { name: "Maintenance mensuelle", price: "49€/mois" },
-    { name: "Référencement avancé", price: "390€" }
-  ];
-
   const faqs = [
     {
       question: "Combien de temps dure un projet ?",
@@ -180,30 +171,6 @@ const ServicesPage: React.FC = () => {
                   Demander un devis
                   <ArrowRight aria-hidden="true" className="ml-2 h-4 w-4" />
                 </Link>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Add-ons Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
-              Services complémentaires
-            </h2>
-            <p className="text-xl text-gray-600">
-              Personnalisez votre projet avec ces options supplémentaires
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {addons.map((addon, index) => (
-              <div key={index} className="bg-white p-6 rounded-xl shadow-sm border">
-                <div className="flex justify-between items-center">
-                  <h3 className="font-semibold text-gray-900">{addon.name}</h3>
-                  <span className="text-blue-600 font-bold">{addon.price}</span>
-                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- remove Services complémentaires add-ons section from Services page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7988c32a4832480688ee478a6e665